### PR TITLE
Potential fix for code scanning alert no. 49: Prototype-polluting function

### DIFF
--- a/packages/weex-template-compiler/build.js
+++ b/packages/weex-template-compiler/build.js
@@ -10,6 +10,12 @@ var he = _interopDefault(require('he'));
 
 var emptyObject = Object.freeze({});
 
+/**
+ * Checks if a property key is a dangerous prototype pollution target.
+ */
+function isReservedKey(key) {
+  return key === '__proto__' || key === 'constructor' || key === 'prototype';
+}
 // These helpers produce better VM code in JS engines due to their
 // explicitness and function inlining.
 function isUndef (v) {
@@ -2814,7 +2820,9 @@ var Observer = function Observer (value) {
 Observer.prototype.walk = function walk (obj) {
   var keys = Object.keys(obj);
   for (var i = 0; i < keys.length; i++) {
-    defineReactive$$1(obj, keys[i]);
+    var key = keys[i];
+    if (isReservedKey(key)) continue;
+    defineReactive$$1(obj, key);
   }
 };
 
@@ -2888,6 +2896,7 @@ function defineReactive$$1 (
   customSetter,
   shallow
 ) {
+  if (isReservedKey(key)) return;
   var dep = new Dep();
 
   var property = Object.getOwnPropertyDescriptor(obj, key);
@@ -2948,6 +2957,10 @@ function defineReactive$$1 (
  * already exist.
  */
 function set (target, key, val) {
+  if (isReservedKey(key)) {
+    process.env.NODE_ENV !== 'production' && warn$1(("Avoid setting reserved property: " + key));
+    return val;
+  }
   if (process.env.NODE_ENV !== 'production' &&
     (isUndef(target) || isPrimitive(target))
   ) {
@@ -3031,7 +3044,7 @@ function mergeData (to, from) {
   for (var i = 0; i < keys.length; i++) {
     key = keys[i];
     // in case the object is already observed...
-    if (key === '__ob__') { continue }
+    if (key === '__ob__' || isReservedKey(key)) { continue }
     toVal = to[key];
     fromVal = from[key];
     if (!hasOwn(to, key)) {


### PR DESCRIPTION
Potential fix for [https://github.com/AlonaHlobina/vue/security/code-scanning/49](https://github.com/AlonaHlobina/vue/security/code-scanning/49)

To prevent prototype pollution, the code must explicitly block dangerous property names when recursively merging, assigning, or defining properties on user-supplied or otherwise potentially tainted objects. The following approach is best, as it is simple, maintainable, and preserves existing behavior for safe keys:

- **Add guards** in all relevant places that iterate over and manipulate keys:
  - In `Observer.prototype.walk`, **skip** keys that are `"__proto__"`, `"constructor"`, or `"prototype"`.
  - In `defineReactive$$1`, **skip** creating properties for these keys.
  - In `set`, **refuse** to set those keys.
  - In `mergeData`, **skip merging** those keys.
- This is best implemented by writing a simple utility function, e.g. `isReservedKey(key)`, returning `true` if the key is one of the "dangerous" strings.
- All the above locations should call this check before performing any sensitive operation.
- No change to API or user-facing behavior for safe property names.

**File(s) to change**:  
Only the shown file, `packages/weex-template-compiler/build.js`. All changes are inserted *within* the shown code snippets.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
